### PR TITLE
Add a console script for starting webhook server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ setup(
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
     entry_points='''
+        [console_scripts]
+        run_webhooks=ckanext.webhooks.eventloop:main
+
         [ckan.plugins]
         webhooks=ckanext.webhooks.plugin:WebhooksPlugin
 


### PR DESCRIPTION
Tiny PR that adds a console script to run the webhook server by adding
run_webhooks to the bin directory.
