### PR TITLE
Adds a minimum viable level of authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,12 +44,23 @@ Supported Topics
 
 Design Decisions
 ==================
-The extension allows users to create webhooks without logging in. This decreases
-friction to creating webhooks and exposes the functionality to more users. The
-main reason for the decision to do it this way is because most governments
+By default the extension allows users to create webhooks without logging in. This
+decreases friction to creating webhooks and exposes the functionality to more users.
+The main reason for the decision to do it this way is because most governments
 (the primary users of CKAN) do not wish to allow account creation in CKAN to the
 public. If we only allow Webhook creation for users with an API key, many CKAN
 users will be left without a way to create Webhooks.
+
+There is a minimal authentication as you may restrict creation of webhooks to users
+who are editors or administrators of organisations.  You may add a config option
+to your CKAN file as below where the value is one of editor, admin, sysadmin or
+none, specifying the minimum roles required to be able to interact with webhooks.
+
+    # Only let sysadmins create hooks
+    ckanext.webhooks.minimum_auth = sysadmin
+
+    # Only let admins and editors create hooks
+    ckanext.webhooks.minimum_auth = editor
 
 Because of this, the extension makes the following decisions:
 

--- a/ckanext/webhooks/actions.py
+++ b/ckanext/webhooks/actions.py
@@ -3,7 +3,7 @@ import logging
 
 from ckan.plugins.toolkit import get_validator, ValidationError
 from ckan.lib.dictization import table_dictize
-from ckan.logic import NotFound
+from ckan.logic import NotFound, check_access
 import ckan.lib.navl.dictization_functions as df
 
 log = logging.getLogger(__name__)
@@ -21,6 +21,9 @@ schema_get = {
 }
 
 def webhook_create(context, data_dict):
+
+    check_access("webhook_create", context, data_dict)
+
     data, errors = df.validate(data_dict, schema, context)
 
     if errors:
@@ -38,6 +41,8 @@ def webhook_create(context, data_dict):
     return webhook.id
 
 def webhook_show(context, data_dict):
+    check_access("webhook_show", context, data_dict)
+
     data, errors = df.validate(data_dict, schema_get, context)
     if errors:
         raise ValidationError(errors)
@@ -49,6 +54,8 @@ def webhook_show(context, data_dict):
     return table_dictize(webhook, context)
 
 def webhook_delete(context, data_dict):
+    check_access("webhook_delete", context, data_dict)
+
     data, errors = df.validate(data_dict, schema_get, context)
     if errors:
         raise ValidationError(errors)

--- a/ckanext/webhooks/auth.py
+++ b/ckanext/webhooks/auth.py
@@ -1,0 +1,65 @@
+import logging
+
+from pylons import config
+
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import ckan.new_authz as new_authz
+
+log = logging.getLogger(__name__)
+
+def _user_has_minumum_role(context):
+    """
+    Determines whether the user has the minimum required role
+    as specific in configuration. This is deliberately verbose.
+    """
+    roles = ['editor', 'admin', 'sysadmin']
+    user = context['user']
+    userobj = model.User.get(user)
+
+    # Do we have a configured minimum role, if not just say ok now.
+    minimum_role = config.get('ckanext.webhooks.minimum_auth', '').lower()
+    if not minimum_role or minimum_role.lower() == 'none':
+        return {'success': True}
+
+    # Validate that the config option is valid and refuse, if we added
+    # the option we probably wanted it to be *something*.
+    if not minimum_role in roles:
+        log.warning("ckanext.webhooks.minimum_auth has an invalid option")
+        return {'success': False}
+
+    # Always let sysadmins do their thing.
+    if new_authz.is_sysadmin(user):
+        return {'success': True}
+
+    # We let sysadmins in just not, so just refuse if we get here.
+    if minimum_role == 'sysadmin':
+        return {'success': False}
+
+    # Determine if the user has the required role in any organization
+    q = model.Session.query(model.Member) \
+        .filter(model.Member.table_name == 'user') \
+        .filter(model.Member.table_id == userobj.id) \
+        .filter(model.Member.state == 'active')
+    roles_for_user = [m.capacity for m in q.all()]
+
+    # If we want admins, let in anyone who has admin
+    if minimum_role == 'admin':
+        if 'admin' in roles_for_user:
+            return {'success': True}
+
+    # Only allow users who have editor
+    if minimum_role == 'editor':
+        if 'editor' in roles_for_user  or 'admin' in roles_for_user:
+            return {'success': True}
+
+    return {'success': False}
+
+def webhook_create(context, data_dict):
+    return _user_has_minumum_role(context)
+
+def webhook_show(context, data_dict):
+    return _user_has_minumum_role(context)
+
+def webhook_delete(context, data_dict):
+    return _user_has_minumum_role(context)

--- a/ckanext/webhooks/plugin.py
+++ b/ckanext/webhooks/plugin.py
@@ -5,6 +5,7 @@ import logging
 import db
 import json
 import actions
+import auth
 import requests
 import ckan.model as model
 
@@ -18,6 +19,8 @@ class WebhooksPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IDomainObjectModification, inherit=True)
     plugins.implements(plugins.IActions, inherit=True)
+    plugins.implements(plugins.IAuthFunctions, inherit=True)
+
 
     # IConfigurer
     def update_config(self, config_):
@@ -60,6 +63,15 @@ class WebhooksPlugin(plugins.SingletonPlugin):
             'webhook_show': actions.webhook_show
         }
         return actions_dict
+
+    def get_auth_functions(self):
+        auth_dict = {
+            'webhook_create': auth.webhook_create,
+            'webhook_delete': auth.webhook_delete,
+            'webhook_show': auth.webhook_show
+        }
+        return auth_dict
+
 
     #Notification functions be here
     def _notify_hooks(self, entity, context, topic):


### PR DESCRIPTION
Allows config to specify a level of permission required to be able to
interact with webhooks.  You can set this to sysadmin to only allow
sysadmins to create hooks, you can set this to admin to only someone
with organization management permissions, or you can set to editor which
will allow anyone who has admin or editor for an organization.  By
default this still allows for anyone to create a webhook (if they're
logged in).
